### PR TITLE
Fixed start script

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 screen
-xdotool getactivewindow key Return # Return out of screen
+sleep 0.5 && xdotool key 'Return' # Return out of screen
 
 python3 -m pip install -r requirements.txt
 python3 app.py

--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,2 @@
-#!/bin/bash
-
-screen
-sleep 0.5 && xdotool key 'Return' # Return out of screen
-
 python3 -m pip install -r requirements.txt
 python3 app.py
-
-xdotool getactivewindow key ctrl+a

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+screen
+xdotool getactivewindow key Return # Return out of screen
+
 python3 -m pip install -r requirements.txt
 python3 app.py
-screen -r
+
+xdotool getactivewindow key ctrl+a


### PR DESCRIPTION
Ok, so the new start script didn't behave as intended. So, I reverted to its previous state and simply removed the line `screen -r'.